### PR TITLE
Solo Uno CAN Configuration Tool

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,15 +1,5 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [platformio]
-default_envs = IMU-LSM6DS3-LIS3MDL
+default_envs = StepperArm
 
 [env:main]
 platform = teensy
@@ -20,9 +10,9 @@ check_tool = cppcheck
 build_src_filter = 
   +<main/*>
 lib_deps = 
-  Nanopb
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
   https://github.com/basicmicro/roboclaw_arduino_library.git
-;   https://github.com/Solo-FL/SOLO-motor-controllers-ARDUINO-library.git#v3.0
 custom_nanopb_protos =
     +<protos/urc.proto>
 
@@ -50,8 +40,8 @@ framework = arduino
 build_src_filter = 
   +<SoloComputerControl/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
 
 custom_nanopb_protos =
     +<protos/urc.proto>
@@ -64,8 +54,8 @@ framework = arduino
 build_src_filter = 
   +<ReadTempRoboclaw/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
   https://github.com/basicmicro/roboclaw_arduino_library.git
 
 custom_nanopb_protos =
@@ -79,9 +69,8 @@ framework = arduino
 build_src_filter = 
   +<StatusLight/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
-  ; Messages
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
 custom_nanopb_protos =
     +<protos/urc.proto>
 
@@ -93,8 +82,8 @@ framework = arduino
 build_src_filter = 
   +<Battery/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
   adafruit/Adafruit SSD1306@^2.5.9
 custom_nanopb_protos =
     +<protos/urc.proto>
@@ -108,8 +97,8 @@ framework = arduino
 build_src_filter = 
   +<StepperArm/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
   https://github.com/janelia-arduino/TMC2209.git
   https://github.com/basicmicro/roboclaw_arduino_library.git
 custom_nanopb_protos =
@@ -123,8 +112,8 @@ framework = arduino
 build_src_filter = 
   +<Science/*>
 lib_deps = 
-  Nanopb
-  QNEthernet
+  Nanopb@^0.4.7
+  QNEthernet@^0.26.0
   https://github.com/janelia-arduino/TMC2209.git
   https://github.com/basicmicro/roboclaw_arduino_library.git
 custom_nanopb_protos =

--- a/scripts/config/80-can.network
+++ b/scripts/config/80-can.network
@@ -1,0 +1,5 @@
+[Match]
+Name=can*
+
+[CAN]
+BitRate=500K

--- a/scripts/config/README.md
+++ b/scripts/config/README.md
@@ -1,0 +1,24 @@
+# Motor Diagnostic CAN tool
+
+Tested with the Innomaker USB2CAN dongle on Linux using python-can.
+
+### Linux Installation
+
+Tested on Ubuntu 22.04 LTS.
+
+```bash
+sudo apt update
+sudo apt install can-utils
+```
+
+```bash
+sudo cp 80-can.network /etc/systemd/network/
+sudo systemctl restart systemd-networkd
+sudo systemctl enable systemd-networkd
+
+```
+
+
+### WSL Installation
+
+https://gist.github.com/yonatanh20/664f07d62eb028db18aa98b00afae5a6

--- a/scripts/config/motor-diagonstic.py
+++ b/scripts/config/motor-diagonstic.py
@@ -1,0 +1,139 @@
+import can
+import time
+from simple_term_menu import TerminalMenu
+
+SCAN_BUS_CHOICE = "Scan Bus"
+TEST_MOTOR_CHOICE = "Test Motor"
+QUIT_CHOICE = "Quit"
+
+
+def main_menu():
+    print("Choose an option:")
+    options = [SCAN_BUS_CHOICE, TEST_MOTOR_CHOICE, QUIT_CHOICE]
+    menu = TerminalMenu(options)
+    return options[menu.show()]
+
+def scan_bus(bus, buffer):
+
+    print("Scanning bus...")
+    ids = [0x6A1, 0x6A2, 0x6A3, 0x6A4, 0x6A5, 0x6A6]
+
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x20, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if msg.arbitration_id in [id & 0xF2F for id in ids]:
+            version_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Found SOLO UNO [id=0x{msg.arbitration_id:x}, version=0x{version_str}]")
+    
+def test_motor(bus, buffer):
+
+    print("Testing motor...")
+
+    ids = [0x6A1, 0x6A2, 0x6A3, 0x6A4, 0x6A5, 0x6A6]
+
+    # Speed mode
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x16, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Speed Control Set [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+
+    # direction CCW
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x0C, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Rotating CCW [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+
+    # speed ref = 2000
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x05, 0x30, 0x00, 0xD0, 0x07, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Speed Ref = 2000 [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+
+    time.sleep(3)
+
+    # direction CW
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x0C, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Rotating CCW [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+
+    time.sleep(3)
+
+    # speed ref = 0
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x05, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Speed Ref = 0 [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+
+    # Torque mode
+    for id in ids:
+        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x16, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00], is_extended_id=False))
+
+    while True:
+        msg = buffer.get_message(timeout=0.1)
+        if msg is None:
+            break
+        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
+            data_str = ''.join(f'{e:x}' for e in msg.data)
+            print(f" Torque Control Set [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+    
+
+
+
+if __name__ == "__main__":
+
+    print("Walli motor configuration tool")
+
+    bus = can.interface.Bus(channel='can0', bustype='socketcan', baud=500000)
+    buffer = can.BufferedReader()
+    notifier = can.Notifier(bus, [buffer])
+
+    try:
+        while True:
+            choice = main_menu()
+
+            if choice == SCAN_BUS_CHOICE:
+                scan_bus(bus, buffer)
+            elif choice == TEST_MOTOR_CHOICE:
+                test_motor(bus, buffer)
+            else:
+                break
+
+        
+    finally:
+        notifier.stop()
+        bus.shutdown()

--- a/scripts/config/motor-diagonstic.py
+++ b/scripts/config/motor-diagonstic.py
@@ -2,115 +2,228 @@ import can
 import time
 from simple_term_menu import TerminalMenu
 
+CAN_BAUD_1000KBPS = 1000000
+CAN_BAUD_500KBPS = 500000
+CAN_BAUD_250KBPS = 250000
+CAN_BAUD_125KBPS = 125000
+CAN_BAUD_100KBPS = 100000
+
+FACTORY_BAUD_RATE = CAN_BAUD_1000KBPS
+DEFAULT_BAUD_RATE = CAN_BAUD_500KBPS
+
+MOTOR_ODRIVE_270KV = "ODRIVE 270KV"
+MOTOR_NEO_470KV = "NEO 470KV"
+
 SCAN_BUS_CHOICE = "Scan Bus"
 TEST_MOTOR_CHOICE = "Test Motor"
+FACTORY_RESET_CHOICE = "Factory Reset"
+CALIBRATE_MOTOR = "Calibrate Motor"
+OK_CHOICE = "OK"
 QUIT_CHOICE = "Quit"
+BACK_CHOICE = "Back"
+
+def sfxtToFloat(input):
+
+    if input >=  0x7FFE0000:
+        return input / 131072.0
+    else:
+        invert = 0xFFFFFFFF - input + 1
+        return invert / -131072.0
 
 
 def main_menu():
     print("Choose an option:")
-    options = [SCAN_BUS_CHOICE, TEST_MOTOR_CHOICE, QUIT_CHOICE]
+    options = [SCAN_BUS_CHOICE, TEST_MOTOR_CHOICE, CALIBRATE_MOTOR, QUIT_CHOICE]
     menu = TerminalMenu(options)
     return options[menu.show()]
 
-def scan_bus(bus, buffer):
 
-    print("Scanning bus...")
-    ids = [0x6A1, 0x6A2, 0x6A3, 0x6A4, 0x6A5, 0x6A6]
+def sendSoloCommand(bus, bufferedReader, idList, payload, message = "Got Message", debug = False, data_func = None, delay_after_send = 0):
 
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x20, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
+    bus.flush_tx_buffer()
+
+    sendIDs = [(0x600 + id) for id in idList]
+    responseIDs = [(0x580 + id) for id in idList]
+
+    for id in sendIDs:
+        bus.send(can.Message(arbitration_id=id, data=payload, is_extended_id=False))
+        time.sleep(0.01)
+
+    time.sleep(delay_after_send)
+
+    data_dict = {}
 
     while True:
-        msg = buffer.get_message(timeout=0.1)
+        msg = bufferedReader.get_message(timeout=0.1)
         if msg is None:
             break
-        if msg.arbitration_id in [id & 0xF2F for id in ids]:
-            version_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Found SOLO UNO [id=0x{msg.arbitration_id:x}, version=0x{version_str}]")
+
+        if msg.arbitration_id in responseIDs:
+
+            id = msg.arbitration_id - 0x580
+            data_dict[id] = [msg.data[4], msg.data[5], msg.data[6], msg.data[7]]
+
+            if debug:
+                if data_func is None:
+                    data_str = ''.join(f'{e:x}' for e in msg.data)
+                    print(f" {message} [id=0x{id:x}, data=0x{data_str}]")
+                else:
+                    print(f" {message} [id=0x{id:x}, {data_func(msg.data)}]")
+
+    return data_dict
+    
+
+def scan_bus(bus, buffer):
+    
+    print("Scanning bus...")
+    
+    ids = [i for i in range(0, 255)]
+    payload = [0x40, 0x3A, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    version_func = lambda arr: f'version={arr[7]:02x}{arr[6]:02x}{arr[5]:02x}{arr[4]:02x}'
+    data = sendSoloCommand(bus, buffer, ids, payload, "Found SOLO UNO", True, version_func, 0)
+    return list(data.keys())
+
     
 def test_motor(bus, buffer):
 
     print("Testing motor...")
 
-    ids = [0x6A1, 0x6A2, 0x6A3, 0x6A4, 0x6A5, 0x6A6]
-
-    # Speed mode
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x16, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Speed Control Set [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
-
-    # direction CCW
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x0C, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Rotating CCW [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
-
-    # speed ref = 2000
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x05, 0x30, 0x00, 0xD0, 0x07, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Speed Ref = 2000 [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
-
-    time.sleep(3)
-
-    # direction CW
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x0C, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Rotating CCW [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
-
-    time.sleep(3)
-
-    # speed ref = 0
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x05, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Speed Ref = 0 [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
-
-    # Torque mode
-    for id in ids:
-        bus.send(can.Message(arbitration_id=id, data=[0x22, 0x16, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00], is_extended_id=False))
-
-    while True:
-        msg = buffer.get_message(timeout=0.1)
-        if msg is None:
-            break
-        if (msg.arbitration_id in [id & 0xF2F for id in ids]):
-            data_str = ''.join(f'{e:x}' for e in msg.data)
-            print(f" Torque Control Set [id=0x{msg.arbitration_id:x}, data=0x{data_str}]")
+    ids = [0x0A1, 0x0A2, 0x0A3, 0x0A4, 0x0A5, 0x0A6]
     
+    payload = [0x22, 0x16, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Speed Control Set")
+
+    payload = [0x22, 0x0C, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Rotating CCW", True)
+
+    payload = [0x22, 0x05, 0x30, 0x00, 0xD0, 0x07, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Speed Ref = 2000")
+
+    time.sleep(3)
+
+    payload = [0x22, 0x0C, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Rotating CW", True)
+
+    time.sleep(3)
+
+    payload = [0x22, 0x05, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Speed Ref = 0")
+
+    payload = [0x22, 0x16, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, ids, payload, "Torque Control Set")
+    
+
+def factory_reset(bus, buffer):
+
+    solos = scan_bus(bus, buffer)
+    print("Select which motor controller you want to factory reset:")
+
+    options = [f'0x{id:x}' for id in solos]
+    options.append(BACK_CHOICE)
+    menu = TerminalMenu(options)
+    choice_idx = menu.show()
+
+    if options[choice_idx] == BACK_CHOICE:
+        print("No SOLO UNO reset.")
+        return
+    
+    id = [solos[choice_idx]]
+    payload = [0x22, 0x14, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Factory Reset SOLO UNO", True)
+
+    time.sleep(3)
+
+    payload = [0x22, 0x2C, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Set CAN baud to 500kbps", True)
+
+    payload = [0x22, 0x01, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    payload[5] = 0x00FF & id[0]
+    payload[6] = 0xFF00 & id[0]
+    sendSoloCommand(bus, buffer, id, payload, f"Set Device Address to 0x{id[0]:x}", True)
+
+    print("Please power cycle SOLO UNO for changes to take effect.")
+
+
+def set_baud_rate():
+    print("What is the CAN baud rate? (Note: upon factory reset, baud rate is 1000kbps)")
+
+    bauds = [CAN_BAUD_1000KBPS, CAN_BAUD_500KBPS, CAN_BAUD_250KBPS, CAN_BAUD_125KBPS, CAN_BAUD_100KBPS]
+    options = [f'{int(b/1000)}kbps' for b in bauds]
+    menu = TerminalMenu(options)
+    choice_idx = menu.show()
+    
+    return bauds[choice_idx]
+
+
+def calibrate_motor(bus, buffer):
+
+    solos = scan_bus(bus, buffer)
+    print("Select which motor controller you want to calibrate:")
+
+    options = [f'0x{id:x}' for id in solos]
+    options.append(BACK_CHOICE)
+    menu = TerminalMenu(options)
+    choice_idx = menu.show()
+
+    if options[choice_idx] == BACK_CHOICE:
+        print("Calibration canceled.")
+        return
+    
+    id = [solos[choice_idx]]
+
+    print(f"What kind of motor is connected to 0x{id[0]:x}?")
+    options = [MOTOR_ODRIVE_270KV, MOTOR_NEO_470KV]
+    menu = TerminalMenu(options)
+    choice_idx = menu.show()
+    motor = options[choice_idx]
+
+    payload = [0x22, 0x02, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Command Mode Digital")
+
+    payload = [0x22, 0x3F, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Motion Profile: Step/Ramp Response")
+
+    payload = [0x22, 0x16, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Torque Control Set")
+
+    payload = [0x22, 0x15, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Motor Type: BLDC-PMSM")
+
+    payload = [0x22, 0x09, 0x30, 0x00, 0x14, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "PWM Frequency: 20kHz")
+
+    payload = [0x22, 0x0F, 0x30, 0x00, 0x0E, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Number of Poles: 14")
+
+    payload = [0x22, 0x03, 0x30, 0x00, 0x00, 0x00, 0x0F, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Current Limit: 7.5")
+
+    print("Motor Identification Procedure")
+    print("WARNING: motor will vibrate!")
+    print("Select 'OK' to proceed.")
+
+    options = [OK_CHOICE, QUIT_CHOICE]
+    menu = TerminalMenu(options)
+    choice_idx = menu.show()
+
+    if options[choice_idx] == QUIT_CHOICE:
+        print("Calibration canceled.")
+        return
+
+    payload = [0x22, 0x07, 0x30, 0x00, 0x01, 0x00, 0x00, 0x00]
+    sendSoloCommand(bus, buffer, id, payload, "Running Motor Parameters Identification")
+
+    time.sleep(1.5)
+
+    payload = [0x40, 0x3A, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    extract_func = lambda arr: arr[4] | (arr[5] << 8) | (arr[6] << 16) | (arr[7] << 24) 
+    format_func = lambda arr: f'{sfxtToFloat(extract_func(arr))}'
+
+    payload = [0x40, 0x17, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00]
+    data = sendSoloCommand(bus, buffer, id, payload, "Current Controller Kp", format_func, 0)
+    my_extract_func = lambda arr: arr[0] | (arr[1] << 8) | (arr[2] << 16) | (arr[3] << 24) 
+    print(f'data=0x{my_extract_func(data[id[0]]):08x}')
+
 
 
 
@@ -118,9 +231,13 @@ if __name__ == "__main__":
 
     print("Walli motor configuration tool")
 
-    bus = can.interface.Bus(channel='can0', bustype='socketcan', baud=500000)
+    # baud = set_baud_rate()
+
+    bus = can.interface.Bus(channel='can0', bustype='socketcan', baud=DEFAULT_BAUD_RATE)
     buffer = can.BufferedReader()
     notifier = can.Notifier(bus, [buffer])
+
+    bus.flush_tx_buffer()
 
     try:
         while True:
@@ -130,6 +247,8 @@ if __name__ == "__main__":
                 scan_bus(bus, buffer)
             elif choice == TEST_MOTOR_CHOICE:
                 test_motor(bus, buffer)
+            elif choice == CALIBRATE_MOTOR:
+                calibrate_motor(bus, buffer)
             else:
                 break
 

--- a/scripts/config/requirements.txt
+++ b/scripts/config/requirements.txt
@@ -1,2 +1,3 @@
 python-can
 simple-term-menu
+tabulate

--- a/scripts/config/requirements.txt
+++ b/scripts/config/requirements.txt
@@ -1,0 +1,2 @@
+python-can
+simple-term-menu


### PR DESCRIPTION
# Description

The Solo UNOs are very tedious to configure using Motion Terminal. The goal of this CAN tool is to make it easier to configure the Solo UNOs using a usb CAN dongle

This PR does the following:
- Creates a terminal-based configuration tool for the Solo UNOs
- options for calibrating motors, resetting motors, testing motors, tuning PID constants, and reading arbitrary values
- Built using InnoMaker USBCAN dongle, but will work with minor changes for any usb CAN dongle compatible with SocketCan on Linux.